### PR TITLE
send_channel

### DIFF
--- a/src/testchannels.cpp
+++ b/src/testchannels.cpp
@@ -3,7 +3,7 @@
 #include <thread>
 #include <unistd.h>
 
-void helper(channel::channel<int> &ch) {
+void helper(channel::send_channel<int> ch) {
   thread_local int i = 0;
   bool closed = ch.closed();
   while (!closed) {
@@ -17,7 +17,7 @@ int main() {
 
   auto ch = channel::channel<int>(5);
 
-  std::thread mythread(helper, std::ref(ch));
+  std::thread mythread(helper, ch);
   int r{};
   for (int i = 0; i < 10; ++i) {
     r = ch.recv();


### PR DESCRIPTION
Putting this here to discuss. May be a way to avoid making send_channel a friend of channel and instead only give access to send_channel's constructor. In order for this to work, the references to channels had to be copies instead. Since we are only copying shared pointers, this shouldn't be a reason for concern, but there may be an additional unnecessary copy with how I've done things here.